### PR TITLE
Support older versions of Capybara with default_wait_time.

### DIFF
--- a/lib/site_prism/element_container.rb
+++ b/lib/site_prism/element_container.rb
@@ -99,7 +99,7 @@ module SitePrism
       method_name = "has_#{element_name}?"
       create_helper_method method_name, *find_args do
         define_method method_name do |*runtime_args|
-          wait_time = SitePrism.use_implicit_waits ? Capybara.default_max_wait_time : 0
+          wait_time = SitePrism.use_implicit_waits ? Waiter.default_wait_time : 0
           Capybara.using_wait_time wait_time do
             element_exists?(*find_args, *runtime_args)
           end
@@ -111,7 +111,7 @@ module SitePrism
       method_name = "has_no_#{element_name}?"
       create_helper_method method_name, *find_args do
         define_method method_name do |*runtime_args|
-          wait_time = SitePrism.use_implicit_waits ? Capybara.default_max_wait_time : 0
+          wait_time = SitePrism.use_implicit_waits ? Waiter.default_wait_time : 0
           Capybara.using_wait_time wait_time do
             element_does_not_exist?(*find_args, *runtime_args)
           end
@@ -123,7 +123,7 @@ module SitePrism
       method_name = "wait_for_#{element_name}"
       create_helper_method method_name, *find_args do
         define_method method_name do |timeout = nil, *runtime_args|
-          timeout = timeout.nil? ? Capybara.default_max_wait_time : timeout
+          timeout = timeout.nil? ? Waiter.default_wait_time : timeout
           Capybara.using_wait_time timeout do
             element_exists?(*find_args, *runtime_args)
           end
@@ -134,7 +134,7 @@ module SitePrism
     def create_visibility_waiter(element_name, *find_args)
       method_name = "wait_until_#{element_name}_visible"
       create_helper_method method_name, *find_args do
-        define_method method_name do |timeout = Capybara.default_max_wait_time, *runtime_args|
+        define_method method_name do |timeout = Waiter.default_wait_time, *runtime_args|
           Timeout.timeout timeout, SitePrism::TimeOutWaitingForElementVisibility do
             Capybara.using_wait_time 0 do
               sleep 0.05 until element_exists?(*find_args, *runtime_args, visible: true)
@@ -147,7 +147,7 @@ module SitePrism
     def create_invisibility_waiter(element_name, *find_args)
       method_name = "wait_until_#{element_name}_invisible"
       create_helper_method method_name, *find_args do
-        define_method method_name do |timeout = Capybara.default_max_wait_time, *runtime_args|
+        define_method method_name do |timeout = Waiter.default_wait_time, *runtime_args|
           Timeout.timeout timeout, SitePrism::TimeOutWaitingForElementInvisibility do
             Capybara.using_wait_time 0 do
               sleep 0.05 while element_exists?(*find_args, *runtime_args, visible: true)

--- a/lib/site_prism/waiter.rb
+++ b/lib/site_prism/waiter.rb
@@ -11,7 +11,7 @@ module SitePrism
     end
 
     def self.default_wait_time
-      Capybara.default_max_wait_time
+      Capybara.respond_to?(:default_max_wait_time) ? Capybara.default_max_wait_time : Capybara.default_wait_time
     end
   end
 end

--- a/spec/waiter_spec.rb
+++ b/spec/waiter_spec.rb
@@ -1,33 +1,36 @@
 require 'spec_helper'
 
-describe SitePrism::Page do
-  it 'should have a default wait time greater than 0' do
-    expect(SitePrism::Waiter.default_wait_time).to be > 0
-  end
-
-  it 'should have respond to wait_until_true' do
-    expect(SitePrism::Waiter).to respond_to :wait_until_true
-  end
-
-  context 'with stubbed timeout' do
-    before { allow(SitePrism::Waiter).to receive(:default_wait_time).and_return 0 }
-
-    it 'should throw a Timeout exception if the block does not become true' do
-      expect { SitePrism::Waiter.wait_until_true { false } }.to raise_error SitePrism::TimeoutException
+describe SitePrism::Waiter do
+  describe '#default_wait_time' do
+    it 'uses Capybara.default_max_wait_time if available' do
+      stub_const("Capybara", double(default_max_wait_time: 1, default_wait_time: 2))
+      expect(described_class.default_wait_time).to be 1
     end
 
-    it 'should return true if block returns true' do
-      expect(SitePrism::Waiter.wait_until_true { true }).to be true
+    it 'uses Capybara.default_wait_time for older versions of Capybara' do
+      stub_const("Capybara", double(default_wait_time: 2))
+      expect(described_class.default_wait_time).to be 2
     end
   end
 
-  it 'should allow custom timeouts' do
-    timeout = (SitePrism::Waiter.default_wait_time >= 2) ? SitePrism::Waiter.default_wait_time / 2 : 3
-    timeout = 0.1
-    margin_of_error = timeout * 0.25
-    start_time = Time.now
-    expect { SitePrism::Waiter.wait_until_true(timeout) { false } }.to raise_error SitePrism::TimeoutException
-    d = Time.now - start_time
-    expect(d).to be_within(margin_of_error).of(timeout)
+  describe '#wait_until_true' do
+    it 'throws a Timeout exception if the block does not become true' do
+      allow(described_class).to receive(:default_wait_time).and_return 0
+      expect { described_class.wait_until_true { false } }.to raise_error SitePrism::TimeoutException
+    end
+
+    it 'returns true if block returns true' do
+      allow(described_class).to receive(:default_wait_time).and_return 0
+      expect(described_class.wait_until_true { true }).to be true
+    end
+
+    it 'allows custom timeouts' do
+      allow(described_class).to receive(:default_wait_time).and_return 1
+      timeout = 0.1
+      start_time = Time.now
+      expect { described_class.wait_until_true(timeout) { false } }.to raise_error SitePrism::TimeoutException
+      d = Time.now - start_time
+      expect(d).to be_within(0.1).of(timeout)
+    end
   end
 end


### PR DESCRIPTION
Merging these two features together for testing purposes.
